### PR TITLE
Linux patches to add more fallbacks to machine-id location

### DIFF
--- a/recipe/0001-Add-var-lib-dbus-machine-id-as-a-fallback.patch
+++ b/recipe/0001-Add-var-lib-dbus-machine-id-as-a-fallback.patch
@@ -1,0 +1,32 @@
+From b86b3ff62dd5c6e8b96625cc30c97acc1b2320a5 Mon Sep 17 00:00:00 2001
+From: Guilherme Quentel Melo <gqmelo@gmail.com>
+Date: Tue, 7 Feb 2017 18:28:43 -0200
+Subject: [PATCH 1/3] Add /var/lib/dbus/machine-id as a fallback
+
+---
+ dbus/dbus-sysdeps-unix.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git dbus/dbus-sysdeps-unix.c dbus/dbus-sysdeps-unix.c
+index ed776a7..19d7b42 100644
+--- dbus/dbus-sysdeps-unix.c
++++ dbus/dbus-sysdeps-unix.c
+@@ -3866,6 +3866,15 @@ _dbus_read_local_machine_uuid (DBusGUID   *machine_id,
+ 
+   dbus_error_free (error);
+ 
++  /* Fallback to the machine ID of system-wide dbus*/
++  _dbus_string_init_const (&filename, "/var/lib/dbus/machine-id");
++
++  b = _dbus_read_uuid_file (&filename, machine_id, FALSE, error);
++  if (b)
++    return TRUE;
++
++  dbus_error_free (error);
++
+   /* Fallback to the system machine ID */
+   _dbus_string_init_const (&filename, "/etc/machine-id");
+   b = _dbus_read_uuid_file (&filename, machine_id, FALSE, error);
+-- 
+2.6.0
+

--- a/recipe/0002-Make-it-possible-to-read-files-on-proc-which-reports.patch
+++ b/recipe/0002-Make-it-possible-to-read-files-on-proc-which-reports.patch
@@ -1,0 +1,49 @@
+From b3b38a320895dfc45418d50ef55f97408b84c170 Mon Sep 17 00:00:00 2001
+From: Guilherme Quentel Melo <gqmelo@gmail.com>
+Date: Wed, 8 Feb 2017 14:22:33 -0200
+Subject: [PATCH 2/3] Make it possible to read files on /proc which reports
+ size zero
+
+---
+ dbus/dbus-file-unix.c | 21 ++++++++++++++++-----
+ 1 file changed, 16 insertions(+), 5 deletions(-)
+
+diff --git dbus/dbus-file-unix.c dbus/dbus-file-unix.c
+index 830d3fe..264f1d4 100644
+--- dbus/dbus-file-unix.c
++++ dbus/dbus-file-unix.c
+@@ -105,15 +105,26 @@ _dbus_file_get_contents (DBusString       *str,
+   
+   total = 0;
+   orig_len = _dbus_string_get_length (str);
+-  if (sb.st_size > 0 && S_ISREG (sb.st_mode))
++  if (sb.st_size >= 0 && S_ISREG (sb.st_mode))
+     {
+       int bytes_read;
+ 
+-      while (total < (int) sb.st_size)
++      while (1)
+         {
+-          bytes_read = _dbus_read (fd, str,
+-                                   sb.st_size - total);
+-          if (bytes_read <= 0)
++          if (total > _DBUS_ONE_MEGABYTE)
++            {
++              dbus_set_error (error, DBUS_ERROR_FAILED,
++                              "File size of \"%s\" is larger than %lu.",
++                              filename_c, (unsigned long) _DBUS_ONE_MEGABYTE);
++              _dbus_close (fd, NULL);
++              return FALSE;
++            }
++          bytes_read = _dbus_read (fd, str, 1024);
++          if (bytes_read == 0)
++            {
++              break;
++            }
++          else if (bytes_read < 0)
+             {
+               dbus_set_error (error, _dbus_error_from_errno (errno),
+                               "Error reading \"%s\": %s",
+-- 
+2.6.0
+

--- a/recipe/0003-Use-proc-sys-kernel-random-boot_id-as-last-resort-fa.patch
+++ b/recipe/0003-Use-proc-sys-kernel-random-boot_id-as-last-resort-fa.patch
@@ -1,0 +1,92 @@
+From 68537537d9b93a7e8b6fdd6e9b442a011fb0b642 Mon Sep 17 00:00:00 2001
+From: Guilherme Quentel Melo <gqmelo@gmail.com>
+Date: Wed, 8 Feb 2017 14:41:16 -0200
+Subject: [PATCH 3/3] Use /proc/sys/kernel/random/boot_id as last resort
+ fallback
+
+---
+ dbus/dbus-internals.c    |  1 +
+ dbus/dbus-string.c       | 20 ++++++++++++++++++++
+ dbus/dbus-string.h       |  2 ++
+ dbus/dbus-sysdeps-unix.c |  9 +++++++++
+ 4 files changed, 32 insertions(+)
+
+diff --git dbus/dbus-internals.c dbus/dbus-internals.c
+index d7ef089..a01f5ef 100644
+--- dbus/dbus-internals.c
++++ dbus/dbus-internals.c
+@@ -720,6 +720,7 @@ _dbus_read_uuid_file_without_creating (const DBusString *filename,
+     goto error;
+ 
+   _dbus_string_chop_white (&contents);
++  _dbus_string_chop_hyphens (&contents);
+ 
+   if (_dbus_string_get_length (&contents) != DBUS_UUID_LENGTH_HEX)
+     {
+diff --git dbus/dbus-string.c dbus/dbus-string.c
+index 98d9f2b..7323fa7 100644
+--- dbus/dbus-string.c
++++ dbus/dbus-string.c
+@@ -2001,6 +2001,26 @@ _dbus_string_chop_white(DBusString *str)
+ }
+ 
+ /**
++ * Deletes hyphens
++ *
++ * @param str the string
++ */
++void
++_dbus_string_chop_hyphens(DBusString *str)
++{
++    unsigned int i;
++    int start = 0;
++    int found;
++
++    for (i = 0; i < 4; i++)
++      {
++        if (!_dbus_string_find (str, start, "-", &found)) break;
++        _dbus_string_delete (str, found, 1);
++        start = found;
++      }
++}
++
++/**
+  * Tests two DBusString for equality.
+  *
+  * @todo memcmp is probably faster
+diff --git dbus/dbus-string.h dbus/dbus-string.h
+index adf709b..1d6a0d2 100644
+--- dbus/dbus-string.h
++++ dbus/dbus-string.h
+@@ -327,6 +327,8 @@ DBUS_PRIVATE_EXPORT
+ void          _dbus_string_delete_leading_blanks (DBusString        *str);
+ DBUS_PRIVATE_EXPORT
+ void          _dbus_string_chop_white            (DBusString        *str); 
++DBUS_PRIVATE_EXPORT
++void          _dbus_string_chop_hyphens          (DBusString        *str);
+ dbus_bool_t   _dbus_string_append_byte_as_hex    (DBusString        *str,
+                                                   unsigned char      byte);
+ DBUS_PRIVATE_EXPORT
+diff --git dbus/dbus-sysdeps-unix.c dbus/dbus-sysdeps-unix.c
+index 19d7b42..5cb957d 100644
+--- dbus/dbus-sysdeps-unix.c
++++ dbus/dbus-sysdeps-unix.c
+@@ -3889,6 +3889,15 @@ _dbus_read_local_machine_uuid (DBusGUID   *machine_id,
+       return TRUE;
+     }
+ 
++  dbus_error_free (error);
++
++  /* Last resort fallback in case there is no system-wide dbus installed */
++  _dbus_string_init_const (&filename, "/proc/sys/kernel/random/boot_id");
++
++  b = _dbus_read_uuid_file (&filename, machine_id, FALSE, error);
++  if (b)
++    return TRUE;
++
+   if (!create_if_not_found)
+     return FALSE;
+ 
+-- 
+2.6.0
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ LDFLAGS=-L${PREFIX}/lib      \
               --disable-systemd \
               --disable-selinux \
               --disable-xml-docs
-make
+make -j${CPU_COUNT}
 make check
 make install
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,14 @@ package:
 source:
   url: http://dbus.freedesktop.org/releases/dbus/dbus-{{ version }}.tar.gz
   md5:  {{ md5 }}
+  patches:
+    - 0001-Add-var-lib-dbus-machine-id-as-a-fallback.patch  # [linux]
+    - 0002-Make-it-possible-to-read-files-on-proc-which-reports.patch  # [linux]
+    - 0003-Use-proc-sys-kernel-random-boot_id-as-last-resort-fa.patch  # [linux]
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
By default dbus look for machine-id on the following paths:

- $PREFIX/var/lib/dbus/machine-id
- /etc/machine-id (FALLBACK)

This works fine as long as the dbus package is used in a conda environment.
But a problem arises when someone tries to ship this dbus package with an application (e.g. a Qt5 application):

- ```$PREFIX/var/lib/dbus/machine-id``` does not exist as it would be inside a conda env (customer has no conda)
- ```/etc/machine-id``` exists only on systems with ```systemd```

Systems without ```systemd``` (e.g. CentOS 6, SUSE 11) will normally have this file in ```/var/lib/dbus/machine-id```, so it seems reasonable to use this file as another fallback.

Without this patch there is no clean way to ship a self contained application to be run on a non-systemd distribution.