### PR TITLE
Update patch to read zero size files

### DIFF
--- a/recipe/0002-Make-it-possible-to-read-files-on-proc-which-reports.patch
+++ b/recipe/0002-Make-it-possible-to-read-files-on-proc-which-reports.patch
@@ -1,32 +1,31 @@
-From b3b38a320895dfc45418d50ef55f97408b84c170 Mon Sep 17 00:00:00 2001
+From 3fd08b871ebfc47d29cdc45f915b98ecb9f68637 Mon Sep 17 00:00:00 2001
 From: Guilherme Quentel Melo <gqmelo@gmail.com>
 Date: Wed, 8 Feb 2017 14:22:33 -0200
 Subject: [PATCH 2/3] Make it possible to read files on /proc which reports
  size zero
 
 ---
- dbus/dbus-file-unix.c | 21 ++++++++++++++++-----
- 1 file changed, 16 insertions(+), 5 deletions(-)
+ dbus/dbus-file-unix.c | 36 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 36 insertions(+)
 
 diff --git dbus/dbus-file-unix.c dbus/dbus-file-unix.c
-index 830d3fe..264f1d4 100644
+index 830d3fe..26bc2b5 100644
 --- dbus/dbus-file-unix.c
 +++ dbus/dbus-file-unix.c
-@@ -105,15 +105,26 @@ _dbus_file_get_contents (DBusString       *str,
-   
-   total = 0;
-   orig_len = _dbus_string_get_length (str);
--  if (sb.st_size > 0 && S_ISREG (sb.st_mode))
-+  if (sb.st_size >= 0 && S_ISREG (sb.st_mode))
-     {
-       int bytes_read;
- 
--      while (total < (int) sb.st_size)
-+      while (1)
-         {
--          bytes_read = _dbus_read (fd, str,
--                                   sb.st_size - total);
--          if (bytes_read <= 0)
+@@ -130,6 +130,42 @@ _dbus_file_get_contents (DBusString       *str,
+           else
+             total += bytes_read;
+         }
++              
++      _dbus_close (fd, NULL);
++      return TRUE;
++    }
++  else if (sb.st_size == 0 && S_ISREG (sb.st_mode))
++    {
++      int bytes_read = -1;
++
++      while (bytes_read != 0)
++        {
 +          if (total > _DBUS_ONE_MEGABYTE)
 +            {
 +              dbus_set_error (error, DBUS_ERROR_FAILED,
@@ -36,14 +35,26 @@ index 830d3fe..264f1d4 100644
 +              return FALSE;
 +            }
 +          bytes_read = _dbus_read (fd, str, 1024);
-+          if (bytes_read == 0)
++          if (bytes_read < 0)
 +            {
-+              break;
++              dbus_set_error (error, _dbus_error_from_errno (errno),
++                              "Error reading \"%s\": %s",
++                              filename_c,
++                              _dbus_strerror (errno));
++
++              _dbus_verbose ("read() failed: %s",
++                             _dbus_strerror (errno));
++
++              _dbus_close (fd, NULL);
++              _dbus_string_set_length (str, orig_len);
++              return FALSE;
 +            }
-+          else if (bytes_read < 0)
-             {
-               dbus_set_error (error, _dbus_error_from_errno (errno),
-                               "Error reading \"%s\": %s",
++          else
++            total += bytes_read;
++        }
+ 
+       _dbus_close (fd, NULL);
+       return TRUE;
 -- 
 2.6.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 3
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
The previous merged PR was not updated with the latest patch. This just
update the patch as it was discussed in the original PR: https://github.com/conda-forge/dbus-feedstock/pull/5